### PR TITLE
Fix log.1 nonexist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN cp "/usr/share/zoneinfo/${TIMEZONE}" /etc/localtime && \
 RUN touch /var/log/cron.log
 
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY goaccess-wrapper.sh /bin/goaccess-wrapper.sh
+RUN chmod +x /entrypoint.sh /goaccess-wrapper.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cp "/usr/share/zoneinfo/${TIMEZONE}" /etc/localtime && \
 RUN touch /var/log/cron.log
 
 COPY entrypoint.sh /entrypoint.sh
-COPY goaccess-wrapper.sh /bin/goaccess-wrapper.sh
+COPY goaccess-wrapper.sh /goaccess-wrapper.sh
 RUN chmod +x /entrypoint.sh /goaccess-wrapper.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ else
 fi
 
 # create cronjob (overriding the predefined alpine cron "run-parts" maintenance pattern)
-echo "${GOACCESS_SCHEDULE} /goaccess-wrapper.sh ${GOACCESS_ARGS} >> /var/log/cron.log 3>&1" > /var/spool/cron/crontabs/root
+echo "${GOACCESS_SCHEDULE} /goaccess-wrapper.sh ${GOACCESS_ARGS} >> /var/log/cron.log 2>&1" > /var/spool/cron/crontabs/root
 echo "" >> /var/spool/cron/crontabs/root
 
 crond

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ else
 fi
 
 # create cronjob (overriding the predefined alpine cron "run-parts" maintenance pattern)
-echo "${GOACCESS_SCHEDULE} /goaccess-wrapper.sh ${GOACCESS_ARGS} >> /var/log/cron.log 2>&1" > /var/spool/cron/crontabs/root
+echo "${GOACCESS_SCHEDULE} /goaccess-wrapper.sh ${GOACCESS_ARGS} >>/var/log/cron.log 2>&1" >/var/spool/cron/crontabs/root
 echo "" >> /var/spool/cron/crontabs/root
 
 crond

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ else
 fi
 
 # create cronjob (overriding the predefined alpine cron "run-parts" maintenance pattern)
-echo "${GOACCESS_SCHEDULE} /bin/goaccess ${GOACCESS_ARGS} >> /var/log/cron.log 2>&1" > /var/spool/cron/crontabs/root
+echo "${GOACCESS_SCHEDULE} /goaccess-wrapper.sh ${GOACCESS_ARGS} >> /var/log/cron.log 3>&1" > /var/spool/cron/crontabs/root
 echo "" >> /var/spool/cron/crontabs/root
 
 crond

--- a/goaccess-wrapper.sh
+++ b/goaccess-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+GOACCESS_ARGS=( "$@" )
+
+# check if log.1 is specified as input file  if file does not exist, then drop from args
+# assuming that current log file (e.g. access.log) and first rotated log (access.log.1)
+# are specified as the first two command line arguments
+if [[ "$2" == *.log.1 ]] && [[ ! -f "$2" ]]; then
+    unset "GOACCESS_ARGS[1]"
+fi
+/bin/goaccess "${GOACCESS_ARGS[*]}"

--- a/goaccess-wrapper.sh
+++ b/goaccess-wrapper.sh
@@ -8,4 +8,5 @@ GOACCESS_ARGS=( "$@" )
 if [[ "$2" == *.log.1 ]] && [[ ! -f "$2" ]]; then
     unset "GOACCESS_ARGS[1]"
 fi
-/bin/goaccess "${GOACCESS_ARGS[*]}"
+
+/bin/goaccess "${GOACCESS_ARGS[@]}"


### PR DESCRIPTION
# MaRDI Pull Request

add wrapper to handle case where log file was not rotated, i.e., access.log.1 does not exist. this applies to the cases 1) logrotate is not running on traefik logs, 2) before the first rotation

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
